### PR TITLE
midi.c: Add a small FIFO for tulp.midi_in().

### DIFF
--- a/tulip/shared/midi.h
+++ b/tulip/shared/midi.h
@@ -10,8 +10,11 @@ void callback_midi_message_received(uint8_t *data, size_t len);
 
 void tulip_midi_isr();
 #define MAX_MIDI_BYTES_PER_MESSAGE 18
-extern uint8_t last_midi[MAX_MIDI_BYTES_PER_MESSAGE];
-extern uint8_t last_midi_len;
+#define MIDI_QUEUE_DEPTH 8
+extern uint8_t last_midi[MIDI_QUEUE_DEPTH][MAX_MIDI_BYTES_PER_MESSAGE];
+extern uint8_t last_midi_len[MIDI_QUEUE_DEPTH];
+extern int16_t midi_queue_tail;
+extern int16_t midi_queue_head;
 
 void midi_out(uint8_t * bytes, uint16_t len);
 #ifdef ESP_PLATFORM

--- a/tulip/shared/modtulip.c
+++ b/tulip/shared/modtulip.c
@@ -491,8 +491,12 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(tulip_bg_touch_callback_obj, 0, 1, tu
 
 
 STATIC mp_obj_t tulip_midi_in(size_t n_args, const mp_obj_t *args) {
-    if(last_midi_len > 0) {
-        return mp_obj_new_bytes(last_midi, last_midi_len);
+    if(midi_queue_head != midi_queue_tail) {
+        int16_t prev_head = midi_queue_head;
+        // Step on the head, hope no-one notices before we pop it.
+        midi_queue_head = (midi_queue_head + 1) % MIDI_QUEUE_DEPTH;
+        return mp_obj_new_bytes(last_midi[prev_head],
+                                last_midi_len[prev_head]);
     } 
     return mp_const_none;
 }


### PR DESCRIPTION
Before this change, any MIDI message was copied into the `last_midi` buffer, and triggers a request to MicroPython to schedule a run of the MIDI callback routine, which then reads back the content of `last_midi` buffer via `tulip.midi_in()`. When generating MIDI events from a USB keyboard, it was easy to overwrite `last_midi` before the MIDI callback had fetched its results, leading to frequent dropped notes when playing chords.

This change adds an 8-entry FIFO between `callback_midi_message_received()` and `tulip.midi_in()`.  Now, you have to press a whole fist of notes down at approximately the same time to overflow the FIFO.