### PR TITLE
esp32s3/usb_keyboard.c: Support hot-swapping QWERTY<>MIDI.

### DIFF
--- a/tulip/esp32s3/usb_keyboard.c
+++ b/tulip/esp32s3/usb_keyboard.c
@@ -19,73 +19,89 @@ typedef union {
     uint8_t val[9];
 } usb_hid_desc_t;
 
-#if DEBUG_USB
+//#define DEBUG_USB
+#ifdef DEBUG_USB
 // from show_desc.hpp
 // from https://github.com/touchgadget/esp32-usb-host-demos
 
-void show_config_desc(const void *p)
-{
-  printf("*** show_config_desc:\n");
-  const usb_config_desc_t *config_desc = (const usb_config_desc_t *)p;
+#define DBGPRINTF(s) printf(s)
+#define DBGPRINTF1(s, a) printf(s, a)
+#define DBGPRINTF2(s, a, b) printf(s, a, b)
+#define DBGPRINTF3(s, a, b, c) printf(s, a, b, c)
+#define DBGPRINTF4(s, a, b, c, d) printf(s, a, b, c, d)
 
-  fprintf(stderr,"bLength: %d\n", config_desc->bLength);
-  fprintf(stderr,"bDescriptorType(config): %d\n", config_desc->bDescriptorType);
-  fprintf(stderr,"wTotalLength: %d\n", config_desc->wTotalLength);
-  fprintf(stderr,"bNumInterfaces: %d\n", config_desc->bNumInterfaces);
-  fprintf(stderr,"bConfigurationValue: %d\n", config_desc->bConfigurationValue);
-  fprintf(stderr,"iConfiguration: %d\n", config_desc->iConfiguration);
-  fprintf(stderr,"bmAttributes(%s%s%s): 0x%02x\n",
-      (config_desc->bmAttributes & USB_BM_ATTRIBUTES_SELFPOWER)?"Self Powered":"",
-      (config_desc->bmAttributes & USB_BM_ATTRIBUTES_WAKEUP)?", Remote Wakeup":"",
-      (config_desc->bmAttributes & USB_BM_ATTRIBUTES_BATTERY)?", Battery Powered":"",
-      config_desc->bmAttributes);
-  fprintf(stderr,"bMaxPower: %d = %d mA\n", config_desc->bMaxPower, config_desc->bMaxPower*2);
-  fprintf(stderr,"***\n");
+void show_config_desc(const void *p, int indent)
+{
+    char prefix[8];
+    for (int i=0; i < indent; ++i) prefix[i] = '*';
+    prefix[indent] = '\0';
+  const usb_config_desc_t *config_desc = (const usb_config_desc_t *)p;
+  fprintf(stderr, "%s CONFIG_DESC(size=%d)\n", prefix, config_desc->bLength);
+  //fprintf(stderr, "bDescriptorType(config): %d\n", config_desc->bDescriptorType);
+  fprintf(stderr, "%s wTotalLength: %d\n", prefix, config_desc->wTotalLength);
+  fprintf(stderr, "%s bNumInterfaces: %d\n", prefix, config_desc->bNumInterfaces);
+  fprintf(stderr, "%s bConfigurationValue: %d\n", prefix, config_desc->bConfigurationValue);
+  fprintf(stderr, "%s iConfiguration: %d\n", prefix, config_desc->iConfiguration);
+  fprintf(stderr, "%s bmAttributes: 0x%02x (%s%s%s)\n", prefix, 
+          config_desc->bmAttributes,
+          (config_desc->bmAttributes & USB_BM_ATTRIBUTES_SELFPOWER)?"Self Powered, ":"",
+          (config_desc->bmAttributes & USB_BM_ATTRIBUTES_WAKEUP)?"Remote Wakeup, ":"",
+          (config_desc->bmAttributes & USB_BM_ATTRIBUTES_BATTERY)?"Battery Powered":"");
+  fprintf(stderr,"%s bMaxPower: %d (%d mA)\n", prefix, config_desc->bMaxPower, config_desc->bMaxPower*2);
 }
 
-uint8_t show_interface_desc(const void *p)
+uint8_t show_interface_desc(const void *p, int indent)
 {
-  fprintf(stderr,"*** show_interface_desc:\n");
+    char prefix[8];
+    for (int i=0; i < indent; ++i) prefix[i] = '*';
+    prefix[indent] = '\0';
   const usb_intf_desc_t *intf = (const usb_intf_desc_t *)p;
 
-  fprintf(stderr,"bLength: %d\n", intf->bLength);
-  fprintf(stderr,"bDescriptorType (interface): %d\n", intf->bDescriptorType);
-  fprintf(stderr,"bInterfaceNumber: %d\n", intf->bInterfaceNumber);
-  fprintf(stderr,"bAlternateSetting: %d\n", intf->bAlternateSetting);
-  fprintf(stderr,"bNumEndpoints: %d\n", intf->bNumEndpoints);
-  fprintf(stderr,"bInterfaceClass: 0x%02x\n", intf->bInterfaceClass);
-  fprintf(stderr,"bInterfaceSubClass: 0x%02x\n", intf->bInterfaceSubClass);
-  fprintf(stderr,"bInterfaceProtocol: 0x%02x\n", intf->bInterfaceProtocol);
-  fprintf(stderr,"iInterface: %d\n", intf->iInterface);
-  fprintf(stderr,"***\n");
+  fprintf(stderr, "%s INTERFACE_DESC(size=%d)\n", prefix, intf->bLength);
+  //fprintf(stderr, "%s bDescriptorType (interface): %d\n", intf->bDescriptorType);
+  fprintf(stderr, "%s bInterfaceNumber: %d\n", prefix, intf->bInterfaceNumber);
+  fprintf(stderr, "%s bAlternateSetting: %d\n", prefix, intf->bAlternateSetting);
+  fprintf(stderr, "%s bNumEndpoints: %d\n", prefix, intf->bNumEndpoints);
+  fprintf(stderr, "%s bInterfaceClass: 0x%02x\n", prefix, intf->bInterfaceClass);
+  fprintf(stderr, "%s bInterfaceSubClass: 0x%02x\n", prefix, intf->bInterfaceSubClass);
+  fprintf(stderr, "%s bInterfaceProtocol: 0x%02x\n", prefix, intf->bInterfaceProtocol);
+  fprintf(stderr, "%s iInterface: %d\n", prefix, intf->iInterface);
   return intf->bInterfaceClass;
 }
 
-void show_endpoint_desc(const void *p)
+void show_endpoint_desc(const void *p, int indent)
 {
-  fprintf(stderr, "*** show_endpoint_desc:\n");
+    char prefix[8];
+    for (int i=0; i < indent; ++i) prefix[i] = '*';
+    prefix[indent] = '\0';
   const usb_ep_desc_t *endpoint = (const usb_ep_desc_t *)p;
   const char *XFER_TYPE_NAMES[] = {
     "Control", "Isochronous", "Bulk", "Interrupt"
   };
-  fprintf(stderr, "bLength: %d\n", endpoint->bLength);
-  fprintf(stderr, "bDescriptorType (endpoint): %d\n", endpoint->bDescriptorType);
-  fprintf(stderr, "bEndpointAddress(%s): 0x%02x\n",
-    (endpoint->bEndpointAddress & USB_B_ENDPOINT_ADDRESS_EP_DIR_MASK)?"In":"Out",
-    endpoint->bEndpointAddress);
-  fprintf(stderr, "bmAttributes(%s): 0x%02x\n",
-      XFER_TYPE_NAMES[endpoint->bmAttributes & USB_BM_ATTRIBUTES_XFERTYPE_MASK],
-      endpoint->bmAttributes);
-  fprintf(stderr, "wMaxPacketSize: %d\n", endpoint->wMaxPacketSize);
-  fprintf(stderr, "bInterval: %d\n", endpoint->bInterval);
-  fprintf(stderr, "***\n");
+  fprintf(stderr, "%s ENDPOINT_DESC(size=%d)\n", prefix, endpoint->bLength);
+  //fprintf(stderr, "%s bDescriptorType (endpoint): %d\n", prefix, endpoint->bDescriptorType);
+  fprintf(stderr, "%s bEndpointAddress: 0x%02x (%s)\n", prefix,
+          endpoint->bEndpointAddress,
+          (endpoint->bEndpointAddress & USB_B_ENDPOINT_ADDRESS_EP_DIR_MASK)?"In":"Out");
+  fprintf(stderr, "%s bmAttributes: 0x%02x (%s)\n", prefix,
+          endpoint->bmAttributes,
+          XFER_TYPE_NAMES[endpoint->bmAttributes & USB_BM_ATTRIBUTES_XFERTYPE_MASK]);
+  fprintf(stderr, "%s wMaxPacketSize: %d\n", prefix, endpoint->wMaxPacketSize);
+  fprintf(stderr, "%s bInterval: %d\n", prefix, endpoint->bInterval);
 }
 
 // end of show_desc.hpp
 #else  // !DEBUG_USB
-#define show_config_desc(p)  /* nothing */
-#define show_interface_desc(p)  /* nothing */
-#define show_endpoint_desc(p)  /* nothing */
+
+#define DBGPRINTF(s)  /* nothing */
+#define DBGPRINTF1(s, a)  /* nothing */
+#define DBGPRINTF2(s, a, b)  /* nothing */
+#define DBGPRINTF3(s, a, b, c)  /* nothing */
+#define DBGPRINTF4(s, a, b, c, d)  /* nothing */
+
+#define show_config_desc(p, i)  /* nothing */
+#define show_interface_desc(p, i)  /* nothing */
+#define show_endpoint_desc(p, i)  /* nothing */
 
 #endif // DEBUG_USB
 
@@ -96,7 +112,8 @@ const size_t USB_HID_DESC_SIZE = 9;
 
 usb_host_client_handle_t Client_Handle;
 usb_device_handle_t Device_Handle;
-static usb_host_enum_cb_t _USB_host_enumerate;
+uint8_t Interface_Number;
+
 bool isKeyboard = false;
 bool isKeyboardReady = false;
 uint8_t KeyboardInterval;
@@ -112,14 +129,17 @@ usb_transfer_t *KeyboardIn = NULL;
 // ---------------------------------
 // from usbhmidi.ino
 bool isMIDI = false;
+bool haveMIDIin = false;
+bool haveMIDIout = false;
 bool isMIDIReady = false;
 
 //const size_t MIDI_IN_BUFFERS = 8;
 //const size_t MIDI_OUT_BUFFERS = 8;
 #define MIDI_IN_BUFFERS 8
-#define MIDI_OUT_BUFFERS 8
+//#define MIDI_OUT_BUFFERS 8
 usb_transfer_t *MIDIOut = NULL;
 usb_transfer_t *MIDIIn[MIDI_IN_BUFFERS] = { NULL };
+
 
 // USB MIDI Event Packet Format (always 4 bytes)
 //
@@ -140,18 +160,18 @@ static void midi_transfer_cb(usb_transfer_t *transfer) {
       uint8_t *const p = transfer->data_buffer;
       for (int i = 0; i < transfer->actual_num_bytes; i += 4) {
         if ((p[i] + p[i + 1] + p[i + 2] + p[i + 3]) == 0) break;
-        printf("midi: %02x %02x %02x %02x\n",
-                 p[i], p[i + 1], p[i + 2], p[i + 3]);
+        DBGPRINTF4("midi: %02x %02x %02x %02x\n",
+                   p[i], p[i + 1], p[i + 2], p[i + 3]);
         // Strip the first byte which is the USB-MIDI virtual wire ID,
         // rest is MIDI message (at least for 3-byte messages).
         callback_midi_message_received(p + i + 1, 3);
       }
       esp_err_t err = usb_host_transfer_submit(transfer);
       if (err != ESP_OK) {
-        printf("usb_host_transfer_submit In fail: %x\n", err);
+        printf("midi usb_host_transfer_submit err: 0x%x\n", err);
       }
     } else {
-      printf("transfer->status %d\n", transfer->status);
+      printf("midi transfer->status %d\n", transfer->status);
     }
   }
 }
@@ -160,12 +180,15 @@ bool check_interface_desc_MIDI(const void *p) {
   const usb_intf_desc_t *intf = (const usb_intf_desc_t *)p;
 
   // USB MIDI
-  if ((intf->bInterfaceClass == USB_CLASS_AUDIO) && (intf->bInterfaceSubClass == 3) && (intf->bInterfaceProtocol == 0)) {
+  if ((intf->bInterfaceClass == USB_CLASS_AUDIO) &&
+      (intf->bInterfaceSubClass == 3) &&
+      (intf->bInterfaceProtocol == 0)) {
     isMIDI = true;
     printf("Claiming a MIDI device!\n");
+    Interface_Number = intf->bInterfaceNumber;
     esp_err_t err = usb_host_interface_claim(Client_Handle, Device_Handle,
-                                             intf->bInterfaceNumber, intf->bAlternateSetting);
-    if (err != ESP_OK) printf("usb_host_interface_claim failed: %x\n", err);
+                                             Interface_Number, intf->bAlternateSetting);
+    if (err != ESP_OK) printf("midi usb_host_interface_claim failed: %x\n", err);
     return true;
   }
   return false;
@@ -177,46 +200,64 @@ void prepare_endpoint_midi(const void *p) {
 
   // must be bulk for MIDI
   if ((endpoint->bmAttributes & USB_BM_ATTRIBUTES_XFERTYPE_MASK) != USB_BM_ATTRIBUTES_XFER_BULK) {
-    printf("Not bulk endpoint: 0x%02x\n", endpoint->bmAttributes);
+    printf("MIDI: Not bulk endpoint: 0x%02x\n", endpoint->bmAttributes);
     return;
   }
   if (endpoint->bEndpointAddress & USB_B_ENDPOINT_ADDRESS_EP_DIR_MASK) {
-    for (int i = 0; i < MIDI_IN_BUFFERS; i++) {
-      err = usb_host_transfer_alloc(endpoint->wMaxPacketSize, 0, &MIDIIn[i]);
-      if (err != ESP_OK) {
-        MIDIIn[i] = NULL;
-        printf("usb_host_transfer_alloc In fail: %x\n", err);
-      } else {
-        MIDIIn[i]->device_handle = Device_Handle;
-        MIDIIn[i]->bEndpointAddress = endpoint->bEndpointAddress;
-        MIDIIn[i]->callback = midi_transfer_cb;
-        MIDIIn[i]->context = (void *)i;
-        MIDIIn[i]->num_bytes = endpoint->wMaxPacketSize;
-        esp_err_t err = usb_host_transfer_submit(MIDIIn[i]);
-        if (err != ESP_OK) {
-          printf("usb_host_transfer_submit In fail: %x\n", err);
+      // MIDI-IN endpoint.
+      for (int i = 0; i < MIDI_IN_BUFFERS; i++) {
+          if (MIDIIn[i] == NULL) {
+              err = usb_host_transfer_alloc(endpoint->wMaxPacketSize, 0, &MIDIIn[i]);
+              if (err != ESP_OK) {
+                  MIDIIn[i] = NULL;
+                  printf("midi usb_host_transfer_alloc/In err: 0x%x\n", err);
+                  haveMIDIout = false;
+                  return;
+              }
+        }
+        if (MIDIIn[i] != NULL) {
+            MIDIIn[i]->device_handle = Device_Handle;
+            MIDIIn[i]->bEndpointAddress = endpoint->bEndpointAddress;
+            MIDIIn[i]->callback = midi_transfer_cb;
+            MIDIIn[i]->context = (void *)i;
+            MIDIIn[i]->num_bytes = endpoint->wMaxPacketSize;
+            esp_err_t err = usb_host_transfer_submit(MIDIIn[i]);
+            if (err != ESP_OK) {
+                printf("midi usb_host_transfer_submit/In err: 0x%x\n", err);
+            }
+            haveMIDIout = true;
         }
       }
-    }
   } else {
-    err = usb_host_transfer_alloc(endpoint->wMaxPacketSize, 0, &MIDIOut);
-    if (err != ESP_OK) {
-      MIDIOut = NULL;
-      printf("usb_host_transfer_alloc Out fail: %x\n", err);
-      return;
-    }
-    printf("Out data_buffer_size: %d\n", MIDIOut->data_buffer_size);
-    MIDIOut->device_handle = Device_Handle;
-    MIDIOut->bEndpointAddress = endpoint->bEndpointAddress;
-    MIDIOut->callback = midi_transfer_cb;
-    MIDIOut->context = NULL;
-    //    MIDIOut->flags |= USB_TRANSFER_FLAG_ZERO_PACK;
+      // MIDI-OUT endpoint
+      if (MIDIOut == NULL) {
+          err = usb_host_transfer_alloc(endpoint->wMaxPacketSize, 0, &MIDIOut);
+          if (err != ESP_OK) {
+              MIDIOut = NULL;
+              printf("midi usb_host_transfer_alloc/Out err: 0x%x\n", err);
+              haveMIDIin = false;
+              return;
+          }
+      }
+      if (MIDIOut != NULL) {
+          DBGPRINTF1("Out data_buffer_size: %d\n", MIDIOut->data_buffer_size);
+          MIDIOut->device_handle = Device_Handle;
+          MIDIOut->bEndpointAddress = endpoint->bEndpointAddress;
+          MIDIOut->callback = midi_transfer_cb;
+          MIDIOut->context = NULL;
+          //    MIDIOut->flags |= USB_TRANSFER_FLAG_ZERO_PACK;
+          haveMIDIin = true;
+      }
   }
-  isMIDIReady = ((MIDIOut != NULL) && (MIDIIn[0] != NULL));
+  // MIDI is ready when both input and output endpoints are initialized.
+  //isMIDIReady = ((MIDIOut != NULL) && (MIDIIn[0] != NULL));
+  isMIDIReady = haveMIDIin && haveMIDIout;
 }
 
 // end of usbhmidi.ino
 // ---------------------------------
+
+void new_enumeration_config_fn(const usb_config_desc_t *config_desc);
 
 
 void _client_event_callback(const usb_host_client_event_msg_t *event_msg, void *arg)
@@ -226,45 +267,60 @@ void _client_event_callback(const usb_host_client_event_msg_t *event_msg, void *
   {
     /**< A new device has been enumerated and added to the USB Host Library */
     case USB_HOST_CLIENT_EVENT_NEW_DEV:
-      //printf("New device address: %d\n", event_msg->new_dev.address);
+      DBGPRINTF1("New device address: %d\n", event_msg->new_dev.address);
       err = usb_host_device_open(Client_Handle, event_msg->new_dev.address, &Device_Handle);
-      if (err != ESP_OK) printf("usb_host_device_open: %x\n", err);
+      if (err != ESP_OK) printf("usb_host_device_open: 0x%x\n", err);
 
       usb_device_info_t dev_info;
       err = usb_host_device_info(Device_Handle, &dev_info);
-      if (err != ESP_OK) printf("usb_host_device_info: %x\n", err);
+      if (err != ESP_OK) printf("usb_host_device_info: 0x%x\n", err);
       //printf("speed: %d dev_addr %d vMaxPacketSize0 %d bConfigurationValue %d\n",
       //    dev_info.speed, dev_info.dev_addr, dev_info.bMaxPacketSize0,
       //    dev_info.bConfigurationValue);
 
       const usb_device_desc_t *dev_desc;
       err = usb_host_get_device_descriptor(Device_Handle, &dev_desc);
-      if (err != ESP_OK) printf("usb_host_get_device_desc: %x\n", err);
+      if (err != ESP_OK) printf("usb_host_get_device_desc: 0x%x\n", err);
 
       const usb_config_desc_t *config_desc;
       err = usb_host_get_active_config_descriptor(Device_Handle, &config_desc);
-      if (err != ESP_OK) printf("usb_host_get_config_desc: %x\n", err);
-      (*_USB_host_enumerate)(config_desc);
+      if (err != ESP_OK) printf("usb_host_get_config_desc: 0x%x\n", err);
+      // Finally, we get to inspect the new device and maybe connect to it.
+      new_enumeration_config_fn(config_desc);
       break;
     /**< A device opened by the client is now gone */
     case USB_HOST_CLIENT_EVENT_DEV_GONE:
-      printf("Device Gone handle: %lx\n", (uint32_t)event_msg->dev_gone.dev_hdl);
+      printf("Device Gone handle: 0x%lx\n", (uint32_t)event_msg->dev_gone.dev_hdl);
+      // Mark everything de-initialized so it will re-initialized on another connect.
+      esp_err_t err;
+      if (isMIDI || isKeyboard) {
+          err = usb_host_interface_release(Client_Handle, Device_Handle, Interface_Number);
+          if (err != ESP_OK) printf("usb_host_interface_release err: 0x%x\n", err);
+          isMIDI = false;
+          isKeyboard = false;
+      }
+      err = usb_host_device_close(Client_Handle, Device_Handle);
+      if (err != ESP_OK) printf("usb_host_device_close err: 0x%x\n", err);
+      isMIDIReady = false;
+      haveMIDIin = false;
+      haveMIDIout = false;
+      isKeyboardReady = false;
       break;
     default:
-      printf("Unknown value %d\n", event_msg->event);
+      printf("Unknown USB event: %d\n", event_msg->event);
       break;
   }
 }
 
 // Reference: esp-idf/examples/peripherals/usb/host/usb_host_lib/main/usb_host_lib_main.c
 
-void usbh_setup(usb_host_enum_cb_t enumeration_cb)
+void usbh_setup()
 {
   const usb_host_config_t config = {
     .intr_flags = ESP_INTR_FLAG_LEVEL1,
   };
   esp_err_t err = usb_host_install(&config);
-  printf("usb_host_install: %x\n", err);
+  DBGPRINTF1("usb_host_install: 0x%x\n", err);
 
   const usb_host_client_config_t client_config = {
     .is_synchronous = false,
@@ -275,9 +331,7 @@ void usbh_setup(usb_host_enum_cb_t enumeration_cb)
     }
   };
   err = usb_host_client_register(&client_config, &Client_Handle);
-  printf("usb_host_client_register: %x\n", err);
-
-  _USB_host_enumerate = enumeration_cb;
+  DBGPRINTF1("usb_host_client_register: 0x%x\n", err);
 }
 
 void usbh_task(void)
@@ -287,21 +341,20 @@ void usbh_task(void)
   esp_err_t err = usb_host_lib_handle_events(HOST_EVENT_TIMEOUT, &event_flags);
   if (err == ESP_OK) {
     if (event_flags & USB_HOST_LIB_EVENT_FLAGS_NO_CLIENTS) {
-      printf("No more clients\n");
+      DBGPRINTF("No more clients\n");
     }
     if (event_flags & USB_HOST_LIB_EVENT_FLAGS_ALL_FREE) {
-      printf("No more devices\n");
+      DBGPRINTF("No more devices\n");
     }
-  }
-  else {
+  } else {
     if (err != ESP_ERR_TIMEOUT) {
-      printf("usb_host_lib_handle_events: %x flags: %lx\n", err, event_flags);
+      printf("usb_host_lib_handle_events: 0x%x flags: %lx\n", err, event_flags);
     }
   }
 
   err = usb_host_client_handle_events(Client_Handle, CLIENT_EVENT_TIMEOUT);
   if ((err != ESP_OK) && (err != ESP_ERR_TIMEOUT)) {
-    printf("usb_host_client_handle_events: %x\n", err);
+    printf("usb_host_client_handle_events: 0x%x\n", err);
   }
 }
 
@@ -360,26 +413,28 @@ void keyboard_transfer_cb(usb_transfer_t *transfer)
         decode_report(p);
       }
       else {
-        printf("Keyboard boot hid transfer too short or long\n");
+          printf("Keyboard boot hid transfer (%d bytes) too short or long\n",
+                 transfer->actual_num_bytes);
       }
     }
     else {
-      printf("transfer->status %d\n", transfer->status);
+      printf("kbd transfer->status %d\n", transfer->status);
     }
   }
 }
 
-bool check_interface_desc_boot_keyboard(const void *p)
-{
+bool check_interface_desc_boot_keyboard(const void *p) {
   const usb_intf_desc_t *intf = (const usb_intf_desc_t *)p;
 
+  // HID Keyboard
   if ((intf->bInterfaceClass == USB_CLASS_HID) &&
       (intf->bInterfaceSubClass == 1) &&
       (intf->bInterfaceProtocol == 1)) {
     isKeyboard = true;
+    Interface_Number = intf->bInterfaceNumber;
     esp_err_t err = usb_host_interface_claim(Client_Handle, Device_Handle,
-        intf->bInterfaceNumber, intf->bAlternateSetting);
-    if (err != ESP_OK) printf("usb_host_interface_claim failed: %x\n", err);
+                                             Interface_Number, intf->bAlternateSetting);
+    if (err != ESP_OK) printf("usb_host_interface_claim failed: 0x%x\n", err);
     return true;
   }
   return false;
@@ -390,79 +445,96 @@ void prepare_endpoint_hid(const void *p)
   const usb_ep_desc_t *endpoint = (const usb_ep_desc_t *)p;
   esp_err_t err;
   keyboard_bytes = usb_round_up_to_mps(KEYBOARD_BYTES, endpoint->wMaxPacketSize);
-  fprintf(stderr, "Setting KB to %d from MPS %d\n", keyboard_bytes, endpoint->wMaxPacketSize);
+  DBGPRINTF2("Setting KB to %d from MPS %d\n", keyboard_bytes, endpoint->wMaxPacketSize);
 
   // must be interrupt for HID
   if ((endpoint->bmAttributes & USB_BM_ATTRIBUTES_XFERTYPE_MASK) != USB_BM_ATTRIBUTES_XFER_INT) {
-    printf("Not interrupt endpoint: 0x%02x\n", endpoint->bmAttributes);
+    printf("Kbd: Not interrupt endpoint: 0x%02x\n", endpoint->bmAttributes);
     return;
   }
   if (endpoint->bEndpointAddress & USB_B_ENDPOINT_ADDRESS_EP_DIR_MASK) {
-    err = usb_host_transfer_alloc(keyboard_bytes, 0, &KeyboardIn);
-    if (err != ESP_OK) {
-      KeyboardIn = NULL;
-      printf("usb_host_transfer_alloc In fail: %x\n", err);
-      return;
-    }
-    KeyboardIn->device_handle = Device_Handle;
-    KeyboardIn->bEndpointAddress = endpoint->bEndpointAddress;
-    KeyboardIn->callback = keyboard_transfer_cb;
-    KeyboardIn->context = NULL;
-    isKeyboardReady = true;
-    KeyboardInterval = endpoint->bInterval;
-    //printf("USB boot keyboard ready\n");
-  }
-  else {
-    printf("Ignoring interrupt Out endpoint\n");
+      if (KeyboardIn == NULL) {
+          err = usb_host_transfer_alloc(keyboard_bytes, 0, &KeyboardIn);
+          if (err != ESP_OK) {
+              KeyboardIn = NULL;
+              printf("kbd usb_host_transfer_alloc/In err: 0x%x\n", err);
+              return;
+          }
+      }
+      if (KeyboardIn != NULL) {
+          KeyboardIn->device_handle = Device_Handle;
+          KeyboardIn->bEndpointAddress = endpoint->bEndpointAddress;
+          KeyboardIn->callback = keyboard_transfer_cb;
+          KeyboardIn->context = NULL;
+          isKeyboardReady = true;
+          KeyboardInterval = endpoint->bInterval;
+          DBGPRINTF("USB boot keyboard ready\n");
+      }
+  } else {
+      DBGPRINTF("Ignoring kbd interrupt Out endpoint\n");
   }
 }
 
-void show_config_desc_full(const usb_config_desc_t *config_desc)
-{
-  // Full decode of config desc.
+void new_enumeration_config_fn(const usb_config_desc_t *config_desc) {
+  // We just retrieved the config of a newly-connected device.
+  // Read through it and see if we can claim a recognized device.
+  //
+  // &config_desc->val[0] is the same as config_desc
+  // so the first "descriptor type" found is actually TYPE_CONFIGURATION
+  // and the call to show_config_desc(p) is equivalent to doing
+  // show_config_desc(config_desc) here.
   const uint8_t *p = &config_desc->val[0];
   uint8_t bLength;
+  int indent = 1;
+  int last_descriptor = -1;
   for (int i = 0; i < config_desc->wTotalLength; i+=bLength, p+=bLength) {
     bLength = *p;
     if ((i + bLength) <= config_desc->wTotalLength) {
       const uint8_t bDescriptorType = *(p + 1);
+      DBGPRINTF3("config_desc->val[%d]: type=%d length=%d\n", i, bDescriptorType, bLength);
       switch (bDescriptorType) {
-        case USB_B_DESCRIPTOR_TYPE_DEVICE:
-          printf("USB Device Descriptor should not appear in config\n");
-          break;
         case USB_B_DESCRIPTOR_TYPE_CONFIGURATION:
-          show_config_desc(p);
+          // The first record in val[] is by definition the config description.
+          show_config_desc(p, indent++);
+          last_descriptor = bDescriptorType;
+          break;
+        case USB_B_DESCRIPTOR_TYPE_DEVICE:
+          DBGPRINTF("USB Device Descriptor should not appear in config\n");
           break;
         case USB_B_DESCRIPTOR_TYPE_STRING:
-          printf("USB string desc TBD\n");
+          DBGPRINTF("USB string desc TBD\n");
           break;
         case USB_B_DESCRIPTOR_TYPE_INTERFACE:
-          show_interface_desc(p);
+          if ((last_descriptor == USB_B_DESCRIPTOR_TYPE_INTERFACE)
+              || (last_descriptor == USB_B_DESCRIPTOR_TYPE_ENDPOINT)) --indent;
+          show_interface_desc(p, indent++);
           if (!isMIDI && !isKeyboard) {
               if (!check_interface_desc_MIDI(p)) {
                   check_interface_desc_boot_keyboard(p);
               }
           }
           if (!isMIDI && !isKeyboard) {
-              printf("Interface was neither keyboard nor midi.\n");
+              DBGPRINTF("Interface was neither keyboard nor midi.\n");
           }
+          last_descriptor = bDescriptorType;
           break;
         case USB_B_DESCRIPTOR_TYPE_ENDPOINT:
-          show_endpoint_desc(p);
-          if (isKeyboard && KeyboardIn == NULL) {
+          show_endpoint_desc(p, indent);
+          if (isKeyboard && !isKeyboardReady) {
               prepare_endpoint_hid(p);
           } else if (isMIDI && !isMIDIReady) {
             prepare_endpoint_midi(p);
           }
+          last_descriptor = bDescriptorType;
           break;
         case USB_B_DESCRIPTOR_TYPE_DEVICE_QUALIFIER:
-          printf("USB device qual desc TBD\n");
+          DBGPRINTF("USB device qual desc TBD\n");
           break;
         case USB_B_DESCRIPTOR_TYPE_OTHER_SPEED_CONFIGURATION:
-          printf("USB Other Speed TBD\n");
+          DBGPRINTF("USB Other Speed TBD\n");
           break;
         case USB_B_DESCRIPTOR_TYPE_INTERFACE_POWER:
-          printf("USB Interface Power TBD\n");
+          DBGPRINTF("USB Interface Power TBD\n");
           break;
         case 0x21:
           // HID 
@@ -487,7 +559,7 @@ void show_config_desc_full(const usb_config_desc_t *config_desc)
 
 void run_usb()
 {
-  usbh_setup(show_config_desc_full);
+  usbh_setup();
   while(1) {
       usbh_task();
       KeyboardTimer = esp_timer_get_time() / 1000;
@@ -510,7 +582,7 @@ void run_usb()
         KeyboardIn->num_bytes = keyboard_bytes; 
         esp_err_t err = usb_host_transfer_submit(KeyboardIn);
         if (err != ESP_OK) {
-          printf("usb_host_transfer_submit In fail: %x\n", err);
+          printf("kbd usb_host_transfer_submit/In err: 0x%x\n", err);
         }
         isKeyboardPolling = true;
         KeyboardTimer = 0;

--- a/tulip/esp32s3/usb_keyboard.h
+++ b/tulip/esp32s3/usb_keyboard.h
@@ -22,11 +22,8 @@ extern uint16_t keyboard_bytes;
 #define KEY_REPEAT_TRIGGER_MS 500
 // How often (in ms) to repeat a key once held
 #define KEY_REPEAT_INTER_MS 90
-typedef void (*usb_host_enum_cb_t)(const usb_config_desc_t *config_desc);
 
-
-void show_config_desc_full(const usb_config_desc_t *config_desc);
-void usbh_setup(usb_host_enum_cb_t enumeration_cb);
+void usbh_setup();
 void run_usb();
 
 #endif


### PR DESCRIPTION
This PR adds proper teardown for the USB Host when a QWERTY keyboard or MIDI keyboard is disconnected.  This makes the USB Host interface ready for another device to be connected. 

Before this change, either a QWERTY keyboard or a MIDI keyboard could be connected to the Tulip USB A socket, but once disconnected, the interface would not recognize any subsequent device connection.

After this change, the user can plug and unplug MIDI and QWERTY keyboards at will.  In particular, they can use a QWERTY keyboard to enter commands to launch software expecting MIDI input, then unplug the QWERTY keyboard, plug in a USB-MIDI keyboard, and play away.

In addition, this PR cleans up some of the diagnostic printouts that occur when DEBUG_USB define is set.
