### PR TITLE
macos/virtualmidi: Bring MacOS MIDI in in-sync with esp32 FIFO changes.

### DIFF
--- a/tulip/macos/virtualmidi.m
+++ b/tulip/macos/virtualmidi.m
@@ -36,7 +36,6 @@ void* run_midi(void*argp){
     if (@available(macOS 11, *))  {
         @autoreleasepool {
             //py_midi_callback = 0;
-            last_midi_len = 0;
 
             OSStatus status = MIDIClientCreate((__bridge CFStringRef)@"Tulip", NotifyProc, NULL, &midi_client);
             if (status != noErr) {
@@ -60,10 +59,11 @@ void* run_midi(void*argp){
                         if(packet->wordCount == 1){
                             const unsigned char *bytes = (unsigned char*)(&packet->words[0]);
                             if(bytes[3] == 0x20) { //  TODO, non-3 packets, then what? 
-                                last_midi[0] = bytes[2];
-                                last_midi[1] = bytes[1];
-                                last_midi[2] = bytes[0];
-                                last_midi_len = 3;
+                                uint8_t data[3];
+                                data[0] = bytes[2];
+                                data[1] = bytes[1];
+                                data[2] = bytes[0];
+                                push_midi_message_into_fifo(data, 3);
                                 tulip_midi_isr();
                                 packet = MIDIEventPacketNext(packet);
                             }

--- a/tulip/shared/midi.c
+++ b/tulip/shared/midi.c
@@ -8,20 +8,7 @@ int16_t midi_queue_tail = 0;
 
 void callback_midi_message_received(uint8_t *data, size_t len) {
     //fprintf(stderr,"got midi message len %ld status %d -- ", (uint32_t)len, data[0]);
-    for(uint32_t i=0;i<(uint32_t)len;i++) {
-        if(i<MAX_MIDI_BYTES_PER_MESSAGE) {
-            //fprintf(stderr, "%d ", data[i]);
-            last_midi[midi_queue_tail][i] = data[i];
-        }
-    }
-    //fprintf(stderr, " ## done\n");
-    last_midi_len[midi_queue_tail] = (uint16_t)len;
-    midi_queue_tail = (midi_queue_tail + 1) % MIDI_QUEUE_DEPTH;
-    if (midi_queue_tail == midi_queue_head) {
-        // Queue wrap, drop oldest item.
-        midi_queue_head = (midi_queue_head + 1) % MIDI_QUEUE_DEPTH;
-        fprintf(stderr, "dropped midi message\n");
-    }
+    push_midi_message_into_fifo(data, len);
     tulip_midi_isr();
 }
 

--- a/tulip/shared/midi.h
+++ b/tulip/shared/midi.h
@@ -16,6 +16,21 @@ extern uint8_t last_midi_len[MIDI_QUEUE_DEPTH];
 extern int16_t midi_queue_tail;
 extern int16_t midi_queue_head;
 
+static inline void push_midi_message_into_fifo(uint8_t *data, int len) {
+    for(uint32_t i = 0; i < (uint32_t)len; i++) {
+        if(i < MAX_MIDI_BYTES_PER_MESSAGE) {
+            last_midi[midi_queue_tail][i] = data[i];
+        }
+    }
+    last_midi_len[midi_queue_tail] = (uint16_t)len;
+    midi_queue_tail = (midi_queue_tail + 1) % MIDI_QUEUE_DEPTH;
+    if (midi_queue_tail == midi_queue_head) {
+        // Queue wrap, drop oldest item.
+        midi_queue_head = (midi_queue_head + 1) % MIDI_QUEUE_DEPTH;
+        fprintf(stderr, "dropped midi message\n");
+    }
+}
+
 void midi_out(uint8_t * bytes, uint16_t len);
 #ifdef ESP_PLATFORM
 void run_midi();


### PR DESCRIPTION
This change at least allows it to compile Tulip Desktop on the Mac again.

I can't test it, but I expect it's OK.