### PR TITLE
Update tulip_desktop.md

### DIFF
--- a/docs/tulip_desktop.md
+++ b/docs/tulip_desktop.md
@@ -44,7 +44,7 @@ Install SDL2:
 
 ```
 # Ubuntu etc
-sudo apt install libsdl2-dev libffi-devel
+sudo apt install libsdl2-dev libffi-dev
 
 # Fedora etc
 sudo yum install SDL2-devel libffi-devel


### PR DESCRIPTION
Ubuntu / Debian header packages end with `-dev`, not `-devel`. So it should be

`sudo apt install libsdl2-dev libffi-dev`