### PR TITLE
T-Deck: Extra Keyboard Characters

### DIFF
--- a/tulip/tdeck/README.md
+++ b/tulip/tdeck/README.md
@@ -13,11 +13,33 @@ We default the T-Deck to a 6x8 REPL font, to get 53x30 REPL / editor screen inst
 
 ![T-Deck](../../docs/pics/tdeck_game.jpg)
 
+Keyboard Characters:
 
+ * They keyboard by default ships with it reporting ASCII codes for each keypress, not any lower-level scan matrix codes, and the Alt key doesn't do anything. You can re-program the keyboard (it's powered by a separate ESP32-C2). It would be great to reprogram this but then others would have to deal with building a flashing jig to reprogram the ESP32-C2, so we may just have to be ok with it.
+ * A raw REPL can be enabled by pressing `sym` and then `shift+b`, to revert back to the normal REPL simply press `sym` and then `shift+l`.
+ * I had to cheat to get access to Control-C and Control-X (save in the editor.) Control-C is accessed by pressing right shift and the dollar sign or speaker key (depending on your model), and Control-X is left shift and the 0/microphone key.
+ * An alternate character set can be accessed by pressing `alt+c`, this should allow the keyboard functionality to be expanded. The following characters are currently available:
+
+ | Default | Alternate | Notes |
+ |---|---|---|
+ | `q` | `~` |  |
+ | `w` | `%` |  |
+ | `e` | `\|` |  |
+ | `r` | `%` |  |
+ | `t` | `{` |  |
+ | `y` | `}` |  |
+ | `(` | `[` | Requires `sym` button to be pressed after `alt+c` |
+ | `)` | `]` | Requires `sym` button to be pressed after `alt+c` |
+ | `u` | `^` |  |
+ | `i` | `<` |  |
+ | `o` | `>` |  |
+ | `p` | `=` |  |
+ | `g` | `\` |  |
+ | `k` | `` ` `` |  |
+ | `<space>` | `<tab>` |  |
 
 Notes:
 
- * They keyboard by default ships with it reporting ASCII codes for each keypress, not any lower-level scan matrix codes, and the Alt key doesn't do anything. You can re-program the keyboard (it's powered by a separate ESP32-C2) but until then, we're limited to the key combos on the device. I had to cheat to get access to Control-C and Control-X (save in the editor.) Control-C is accessed by pressing right shift and the dollar sign or speaker key (depending on your model), and Control-X is left shift and the 0/microphone key. I haven't been able to find `TAB` yet either. It would be great to reprogram this but then others would have to deal with building a flashing jig to reprogram the ESP32-C2, so we may just have to be ok with it.
  * The trackball is mapped to the arrow keys.
  * USB for MIDI and real keyboard *should* work, but it's annoying to test as the UART for monitoring goes over the same USB connection. There's a header on back for serial monitoring, so I'll eventually move to that and try to get USB working. Alternatively we could use MIDI over the exposed UART pins, but that would require a separate breakout board. 
  * If you get your T-Deck in a state where your computer can't find its USB-Serial connection anymore (probably because you're doing something with USB on Tulip), you have to force it back into bootloader mode before it'll flash again. To do that, flip it off, then hold down the trackball button (GPIO0) while flipping it back on again. You can let go of the ball right after you flip it on. The next time you flash, it'll stay in bootloader mode until you hit the "reset" button (opposite side from the power switch.) If you're trying to connect to the monitor, you'll see "waiting for download" -- that's your hint to hit the reset button.
@@ -31,7 +53,7 @@ Still todo
  * SD card support
  * LoRA 
  * Battery voltage reporting
- * Reprogram the keyboard to make ALT be CTRL 
+ * Integrate `CTRL` into the current keyboard implementation
  * Microphone support 
  * Try 120MHz SPI 
 

--- a/tulip/tdeck/tdeck_keyboard.c
+++ b/tulip/tdeck/tdeck_keyboard.c
@@ -17,8 +17,11 @@
 
 int state = 0;
 QueueHandle_t interruptQueue;
-bool alt_char_mode = false;
-struct CharMapping {
+struct KeyMapping {
+    // The following characters should be available to map to an alternative
+    // Default: q w e r t y u i o p a s d f g h j k l z x c v b n m $  
+    // Shift: Q W E R T Y U I O P A S D F G H J K L Z X C V B N M
+    // Symbol: # 1 2 3 ( ) _ - + @ * 4 5 6 / : ; \ " 7 8 9 ? ! , . 0
     char original;
     char alternative;
 };
@@ -50,7 +53,7 @@ void watch_trackball(void *params)
     }
 }
 
-char get_alternative_char(struct CharMapping mappings[], int size, char original) {
+char get_alternative_char(struct KeyMapping mappings[], int size, char original) {
     for (int i = 0; i < size; ++i) {
         if (mappings[i].original == original) {
             return mappings[i].alternative;
@@ -62,26 +65,64 @@ char get_alternative_char(struct CharMapping mappings[], int size, char original
 
 void run_tdeck_keyboard() {
 
+    bool alt_char_mode = false;
+    bool ctrl_toggle = false;
     uint8_t rx_data[5];
-    struct CharMapping charMappings[] = {
+    uint8_t char_to_send[1];
+    struct KeyMapping charMappings[] = {
+        // Default keys
         {'q', '~'},
         {'w', '&'},
         {'e', '|'},
         {'r', '%'},
         {'t', '{'},
         {'y', '}'},
-        {'(', '['},     // Requires symbol button to be pressed after activating alternate character mode
-        {')', ']'},     // Requires symbol button to be pressed after activating alternate character mode
         {'u', '^'},
         {'i', '<'},
         {'o', '>'},
         {'p', '='},
+        {'a', 172},     // Prints an empty character but should be a ¬ sign
         {'g', '\\'},    // Backslash needs escaping
         {'k', '`'},
-        {' ', '\t'},
-        // Add more mappings as needed
+        {'$', 163},     // Prints an empty character but should be a £ sign
+        {' ', '\t'},    // Sends tab
+        // Requires symbol to be pressed after alt+c
+        {'(', '['},
+        {')', ']'},
     };
-    int mappingsSize = sizeof(charMappings) / sizeof(charMappings[0]);
+    struct KeyMapping ctrlMappings[] = {
+        // Default keys
+        {'q', 17},      // Device Control 1
+        {'w', 23},      // End of Transmission Block
+        {'e', 5},       // Enquiry character
+        {'r', 18},      // Device Control 2
+        {'t', 20},      // Device Control 4
+        {'y', 25},      // End of Medium
+        {'u', 21},      // Negative-acknowledge character
+        {'i', 9},       // Horizontal tab
+        {'o', 15},      // Shift In
+        {'p', 16},      // Data Link Escape
+        {'a', 1},       // Start of Heading
+        {'s', 19},      // Device Control 3
+        {'d', 4},       // End-of-transmission character
+        {'f', 6},       // Acknowledge character
+        {'g', 7},       // Bell character
+        {'h', 8},       // Backspace
+        {'j', 10},      // Linefeed
+        {'k', 11},      // Vertical tab
+        {'l', 12},      // Formfeed
+        {'z', 26},      // Substitute character
+        {'x', 24},      // Cancel character
+        {'c', 3},       // End-of-text character
+        {'v', 22},      // Synchronous Idle
+        {'b', 2},       // Start of Text
+        {'n', 14},      // Shift Out
+        {'m', 13},      // Carriage return
+        {'$', 127},     // Delete (DEL)
+        {' ', 27},      // Escape character
+    };
+    int charMappingsSize = sizeof(charMappings) / sizeof(charMappings[0]);
+    int ctrlMappingsSize = sizeof(ctrlMappings) / sizeof(ctrlMappings[0]);
 
     i2c_config_t conf = {
         .mode = I2C_MODE_MASTER,
@@ -131,28 +172,28 @@ void run_tdeck_keyboard() {
 
     while (1) {
         i2c_master_read_from_device(I2C_NUM_0, LILYGO_KB_SLAVE_ADDRESS, rx_data, 1, pdMS_TO_TICKS(TIMEOUT_MS));
-        if(rx_data[0]>0) {
-            // Send shift-$ or shift-volume as control C
-            if(rx_data[0]==4) { 
-                send_key_to_micropython(3); // ctrl c
-            // Send shift 0 or shift-microphone as control X
-            } else if(rx_data[0]==224) {
-                send_key_to_micropython(24); 
-            } else if(rx_data[0]==12) { 
+        if (rx_data[0] > 0) {
+            if (rx_data[0] == 224) {
+                // Toggle ctrl key (shift+microphone)
+                ctrl_toggle = !ctrl_toggle;
+            } else if (rx_data[0] == 12) {
                 // Set alternate character mode
-                if (alt_char_mode == true) {
+                alt_char_mode = !alt_char_mode;
+            } else {
+                if (alt_char_mode) {
+                    // Send alternate characters if alternate character set is enabled, otherwise send as is
+                    char_to_send[0] = get_alternative_char(charMappings, charMappingsSize, rx_data[0]);
                     alt_char_mode = false;
                 } else {
-                    alt_char_mode = true;
+                    char_to_send[0] = rx_data[0];
                 }
-            } else if (alt_char_mode == true) {
-                // Send alternate characters
-                send_key_to_micropython(get_alternative_char(charMappings, mappingsSize, rx_data[0]));
-                // Reset back to default character set after sending the key, remove this line if a toggle is preferred
-                alt_char_mode = false;
-            } else {
-                // Send as is
-                send_key_to_micropython(rx_data[0]);
+                // Send as is, combining with ctrl if toggled
+                if (ctrl_toggle) {
+                    send_key_to_micropython(get_alternative_char(ctrlMappings, ctrlMappingsSize, char_to_send[0]));
+                    ctrl_toggle = false;  // Reset toggle after sending
+                } else {
+                    send_key_to_micropython(char_to_send[0]);
+                }
             }
         }
     }


### PR DESCRIPTION
As mentioned in the discussion thread https://github.com/bwhitman/tulipcc/discussions/146#discussioncomment-7738780 here is a PR which provides extra characters to the T-Deck keyboard.

I listen for `alt+c` which the keyboard firmware provides as a formfeed character, this is used to enable an alternate character mode using a bool. On the next key press if the key pressed has an alternative character configured within the `CharMappings` struct it will return the alternative character otherwise it will return the original character, then it will reset the bools state to false to mimic the `sym` key behaviour.

The following extra characters are currently implemented:

 | Default | Alternate | Notes |
 |---|---|---|
 | `q` | `~` |  |
 | `w` | `%` |  |
 | `e` | `\|` |  |
 | `r` | `%` |  |
 | `t` | `{` |  |
 | `y` | `}` |  |
 | `(` | `[` | Requires `sym` button to be pressed after `alt+c` |
 | `)` | `]` | Requires `sym` button to be pressed after `alt+c` |
 | `u` | `^` |  |
 | `i` | `<` |  |
 | `o` | `>` |  |
 | `p` | `=` |  |
 | `g` | `\` |  |
 | `k` | `` ` `` |  |
 | `<space>` | `<tab>` |  |

In its current state this PR doesn't provide the much needed `ctrl` and `alt` keys along with a few other notable omissions like `£`. These should be able to be implemented with a little extra work/logic as each key can now provide 2 extra characters on top of the ones printed on the keyboard.

I would love to hear your thoughts on the implementation and whether it could be improved.