### PR TITLE
Fix linux build

### DIFF
--- a/docs/tulip_desktop.md
+++ b/docs/tulip_desktop.md
@@ -48,6 +48,9 @@ sudo apt install libsdl2-dev libffi-dev
 
 # Fedora etc
 sudo yum install SDL2-devel libffi-devel
+
+# Arch
+sudo pacman -S sdl2 libffi
 ```
 
 Build and run:

--- a/tulip/linux/Makefile
+++ b/tulip/linux/Makefile
@@ -30,6 +30,26 @@ UNAME_S := $(shell uname -s)
 include $(TOP)/py/py.mk
 include $(TOP)/extmod/extmod.mk
 
+# LVGL stuff
+LVGL_BINDING_DIR = $(TOP)/../lv_binding_micropython_tulip
+LVGL_DIR = $(LVGL_BINDING_DIR)/lvgl
+LVGL_GENERIC_DRV_DIR = $(LVGL_BINDING_DIR)/driver/generic
+INC += -I$(LVGL_BINDING_DIR) -I.
+ALL_LVGL_SRC = $(shell find $(LVGL_DIR) -type f) 
+LVGL_PP = $(BUILD)/lvgl/lvgl.pp.c
+LVGL_MPY = $(BUILD)/lvgl/lv_mpy.c
+LVGL_MPY_METADATA = $(BUILD)/lvgl/lv_mpy.json
+QSTR_GLOBAL_DEPENDENCIES += $(LVGL_MPY)
+CFLAGS_MOD += $(LV_CFLAGS) 
+SRC_C += $(shell find $(LVGL_DIR)/src -type f -name '*.c')
+CFLAGS += -DLV_CONF_INCLUDE_SIMPLE
+
+$(LVGL_MPY): $(ALL_LVGL_SRC) $(LVGL_BINDING_DIR)/gen/gen_mpy.py 
+	$(ECHO) "LVGL-GEN $@"
+	$(Q)mkdir -p $(dir $@)
+	$(Q)$(CPP) $(LV_CFLAGS) -DLVGL_PREPROCESS -I $(LVGL_BINDING_DIR)/pycparser/utils/fake_libc_include $(INC) $(LVGL_DIR)/lvgl.h > $(LVGL_PP)
+	$(Q)$(PYTHON) $(LVGL_BINDING_DIR)/gen/gen_mpy.py -M lvgl -MP lv -MD $(LVGL_MPY_METADATA) -E $(LVGL_PP) $(LVGL_DIR)/lvgl.h > $@
+
 #GIT_SUBMODULES += lib/axtls lib/berkeley-db-1.xx lib/libffi lib/mbedtls lib/micropython-lib 
 
 INC +=  -I.
@@ -41,6 +61,8 @@ INC += -I../shared/
 INC += -I../../amy/src/
 INC += -I$(TOP)/lib/mbedtls/include
 INC += -I/usr/include/SDL2
+INC += -I$(TOP)/../lv_binding_micropython_tulip/lvgl/src
+INC += -I$(TOP)/../lv_binding_micropython_tulip/lvgl/src/libs/lodepng
 
 # compiler settings
 CWARN = -Wall 


### PR DESCRIPTION
I'm on Arch and I'm trying to get the build for Tulip Desktop working. It looks like the recent change to fork lvgl hasn't been accounted for in the linux Makefiles, so that may be partially accounted for, but now lvgl seems to be calling `m_free` and `m_realloc` in micropython incorrectly. I'll open this as a draft for now and keep investigating.

Please let me know if the linux build is way behind the mac/other builds and needs a lot of work - I'm not super familiar with these build systems and so if that's the case I might have to give up and leave it to the professionals :sweat_smile:

<details>
<summary>Here's the error in the build</summary>

```
CC ../../micropython/../lv_binding_micropython_tulip/lvgl/src/stdlib/builtin/lv_string_builtin.c
../../micropython/../lv_binding_micropython_tulip/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c: In function ‘lv_realloc_core’:
../../micropython/../lv_binding_micropython_tulip/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c:70:12: error: too few arguments to function ‘m_realloc’
   70 |     return m_realloc(p, new_size);
      |            ^~~~~~~~~
In file included from ../../micropython/../lv_binding_micropython_tulip/include/lv_mp_mem_custom_include.h:5,
                 from ../../micropython/../lv_binding_micropython_tulip/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c:11:
../../micropython/py/misc.h:102:7: note: declared here
  102 | void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes);
      |       ^~~~~~~~~
../../micropython/../lv_binding_micropython_tulip/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c: In function ‘lv_free_core’:
../../micropython/../lv_binding_micropython_tulip/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c:75:5: error: too few arguments to function ‘m_free’
   75 |     m_free(p);
      |     ^~~~~~
../../micropython/py/misc.h:104:6: note: declared here
  104 | void m_free(void *ptr, size_t num_bytes);
      |      ^~~~~~
../../micropython/../lv_binding_micropython_tulip/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c: In function ‘lv_realloc_core’:
../../micropython/../lv_binding_micropython_tulip/lvgl/src/stdlib/micropython/lv_mem_core_micropython.c:71:1: warning: control reaches end of non-void function [-Wreturn-type]
   71 | }
      | ^
See https://github.com/micropython/micropython/wiki/Build-Troubleshooting
```

</details>